### PR TITLE
Update server.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -270,7 +270,7 @@ Server.prototype.close = function close () {
  * Proxy the event listener requests to the created Net server
  */
 
-Object.keys(process.EventEmitter.prototype).forEach(function proxy (key){
+Object.keys(require('events').prototype).forEach(function proxy (key){
   Server.prototype[key] = Server.prototype[key] || function () {
     if (this.socket) {
       this.socket[key].apply(this.socket, arguments);


### PR DESCRIPTION
process.EventEmitter is deprecated. use require('events') instead